### PR TITLE
Add FuturesSettlement and ACAT txn variants

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -416,6 +416,10 @@ pub mod transactions {
         SellToClose,
         #[serde(rename = "Buy to Close")]
         BuyToClose,
+        #[serde(rename = "Futures Settlement")]
+        FuturesSettlement,
+        #[serde(rename = "ACAT")]
+        ACAT,
     }
 
     impl PartialEq for ReceiveDeliver {


### PR DESCRIPTION
Adds `FuturesSettlement` and `ACAT` variants to the `ReceiveDeliverTransactionSubType` enum.

Fixes #3.